### PR TITLE
Add documentation link to mobile hamburger menu

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -68,6 +68,11 @@ function HamburgerDropdown() {
               Advisors
             </Text>
           </Link>
+          <AnchorLink href="https://paper.element.fi/" target="_blank">
+            <Text variant="subHeading" sx={{ fontWeight: "semiBold" }}>
+              Documentation
+            </Text>
+          </AnchorLink>
         </Grid>
       </Card>
       <Grid sx={{ alignContent: "center" }}>


### PR DESCRIPTION
Adds the link to the construction paper which was missing from the mobile hamburger menu:

![image](https://user-images.githubusercontent.com/4524175/114922997-29d59e00-9de1-11eb-8058-b9a89b22a741.png)
